### PR TITLE
[Fix]: Enable Avro logical types During Restore

### DIFF
--- a/src/main/java/com/bigquery/app/common/bigquery/BigQueryService.java
+++ b/src/main/java/com/bigquery/app/common/bigquery/BigQueryService.java
@@ -137,7 +137,10 @@ public class BigQueryService {
                     .setFieldDelimiter(fieldDelimiter)
                     .build());
             case "JSON" -> configBuilder.setFormatOptions(FormatOptions.json());
-            case "AVRO" -> configBuilder.setFormatOptions(FormatOptions.avro());
+            case "AVRO" ->  {
+                configBuilder.setFormatOptions(FormatOptions.avro());
+                configBuilder.setUseAvroLogicalTypes(true);
+            }
             case "PARQUET" -> configBuilder.setFormatOptions(FormatOptions.parquet());
             default -> throw new ValidationException("Unsupported format: " + format);
         }


### PR DESCRIPTION
## Description
As per the explanation [here](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro?_gl=1*ljkhd3*_ga*MTQyODY2Mzg5MC4xNzM4NjYwODc5*_ga_WH2QY8WWF5*MTc0NTMyNzYwNS4xNjEuMC4xNzQ1MzI3NjA1LjAuMC4w) using Avro Logical type while restoring Bigquery avoids type conversion issues.



